### PR TITLE
Update example to use store2realm as a cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,5 +124,21 @@ public class PostService extends StoreService<Post> {
 ````
 
 
+## Cache and errors
+
+In certain cases, if you use network in a Store and there is no connection, you will have receive an error. The realm service
+won't act as a cache. Store2Store is a syncing system, not a cache for offline usage; if you want to use Store2Realm as a cache
+for your data, you can easily do it passing a second argument (true) to the `observeOn` method.
+
+```
+postService.getAll(filter, sortingMode)
+    .subscribeOn(Schedulers.io())
+    .observeOn(AndroidSchedulers.mainThread(), true) // add true here if you want to delay the error and receive the realm update first
+    ...
+```
+
+You can have a look to the example application in the project to see this in action.
+
+
 ## Contributors
 Please see [CONTRIBUTORS.md](https://github.com/playmoweb/store2realm/blob/master/CONTRIBUTORS.md)

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,15 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath "io.realm:realm-gradle-plugin:3.7.2"
+        classpath "io.realm:realm-gradle-plugin:4.3.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,6 +23,10 @@ allprojects {
         jcenter()
         maven { url 'https://jitpack.io' }
         maven { url 'https://maven.google.com' }
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "io.realm:realm-gradle-plugin:3.7.2"
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'realm-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.playmoweb.store2realm.example"

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.playmoweb.store2realm.example">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:name=".ExampleApplication"
@@ -12,7 +12,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".ui.MainActivity" android:screenOrientation="portrait">
+        <activity
+            android:name=".ui.MainActivity"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/example/src/main/java/com/playmoweb/store2realm/example/data/services/PostService.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/data/services/PostService.java
@@ -29,9 +29,8 @@ public class PostService extends StoreService<Post> {
     @Inject
     public PostService(ApiService apiService) {
         super(Post.class, new PostDao(apiService));
-        this.syncWith(new BaseRealmService<>(Post.class, true)); // realm as cache (boolean)
+        this.syncWith(new BaseRealmService<>(Post.class)); // realm as cache (boolean)
     }
-
 
     /**
      * Post DAO impl

--- a/example/src/main/java/com/playmoweb/store2realm/example/data/services/PostService.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/data/services/PostService.java
@@ -20,17 +20,18 @@ import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
 
 /**
- * @author  Thibaud Giovannetti
- * @by      Playmoweb
- * @date    10/09/2017
+ * @author Thibaud Giovannetti
+ * @by Playmoweb
+ * @date 10/09/2017
  */
 public class PostService extends StoreService<Post> {
 
     @Inject
     public PostService(ApiService apiService) {
         super(Post.class, new PostDao(apiService));
-        this.syncWith(new BaseRealmService<>(Post.class));
+        this.syncWith(new BaseRealmService<>(Post.class, true)); // realm as cache (boolean)
     }
+
 
     /**
      * Post DAO impl
@@ -48,7 +49,7 @@ public class PostService extends StoreService<Post> {
             // this IF case is here only to demonstrate the usage of filtering and sorting mode in the UI
             // this logic should be on the server side and not here !
             // !!!! The filter and the sort are hardcoded here (to match presenter choices).
-            if(sortingMode != null && filter != null){
+            if (sortingMode != null && filter != null) {
                 final int userIdAllowed = (int) filter.entrySet().iterator().next().getValue().value;
 
                 // special return for demo

--- a/example/src/main/java/com/playmoweb/store2realm/example/ui/MainActivity.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/ui/MainActivity.java
@@ -67,11 +67,17 @@ public class MainActivity extends AppCompatActivity implements MainView {
         listOfPosts.setAdapter(adapter);
 
         // mainPresenter.loadPosts(false); // load posts
+        mainPresenter.loadPosts(false);
     }
 
     private void disableButtons(boolean disable){
         allButton.setEnabled(!disable);
         filteredButton.setEnabled(!disable);
+    }
+
+    @Override
+    protected void onPostResume() {
+        super.onPostResume();
     }
 
     @Override
@@ -87,7 +93,16 @@ public class MainActivity extends AppCompatActivity implements MainView {
         Toast.makeText(this, "UI refreshed with datas", Toast.LENGTH_LONG).show();
     }
 
+    @Override
+    public void showError(String message) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+    }
+
     private void updateAdapter(List<Post> posts){
+        if(posts == null){
+            return;
+        }
+
         String[] items = new String[posts.size()];
         for(int i = 0; i < posts.size(); i++){
             final Post p = posts.get(i);

--- a/example/src/main/java/com/playmoweb/store2realm/example/ui/MainActivity.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/ui/MainActivity.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.playmoweb.store2realm.example.ExampleApplication;
@@ -32,6 +33,7 @@ public class MainActivity extends AppCompatActivity implements MainView {
     private ListView listOfPosts;
     private Button allButton;
     private Button filteredButton;
+    private TextView errorMessage;
 
     private ArrayAdapter<String> adapter;
 
@@ -46,6 +48,7 @@ public class MainActivity extends AppCompatActivity implements MainView {
         listOfPosts = findViewById(R.id.listOfPosts);
         allButton = findViewById(R.id.allButton);
         filteredButton = findViewById(R.id.filteredButton);
+        errorMessage = findViewById(R.id.errorMessage);
 
         allButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -90,12 +93,18 @@ public class MainActivity extends AppCompatActivity implements MainView {
     public void updatePosts(List<Post> posts){
         disableButtons(false);
         updateAdapter(posts);
-        Toast.makeText(this, "UI refreshed with datas", Toast.LENGTH_LONG).show();
+        Toast.makeText(this, "UI updated", Toast.LENGTH_SHORT).show();
     }
 
     @Override
     public void showError(String message) {
+        errorMessage.setVisibility(View.VISIBLE);
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void hideError() {
+        errorMessage.setVisibility(View.GONE);
     }
 
     private void updateAdapter(List<Post> posts){

--- a/example/src/main/java/com/playmoweb/store2realm/example/ui/MainPresenter.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/ui/MainPresenter.java
@@ -57,17 +57,21 @@ public class MainPresenter {
                 .subscribeWith(new DisposableSubscriber<Optional<List<Post>>>(){
                     @Override
                     public void onNext(Optional<List<Post>> items) {
-                        mainView.updatePosts(items.get());
+                        if(!items.isNull()){
+                            mainView.updatePosts(items.get());
+                        } else {
+                            // show up network error (syncing error on your PostService Store)
+                        }
                     }
 
                     @Override
                     public void onError(Throwable e) {
                         e.printStackTrace();
+                        mainView.updatePosts(null);
                     }
 
                     @Override
                     public void onComplete() {
-
                     }
                 });
 

--- a/example/src/main/java/com/playmoweb/store2realm/example/ui/MainPresenter.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/ui/MainPresenter.java
@@ -44,6 +44,8 @@ public class MainPresenter {
     }
 
     public void loadPosts(boolean filterAndSortPosts) {
+        mainView.hideError();
+
         SortingMode sortingMode = null;
         Filter filter = null;
         if(filterAndSortPosts){
@@ -53,14 +55,12 @@ public class MainPresenter {
 
         Disposable d = postService.getAll(filter, sortingMode)
                 .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(AndroidSchedulers.mainThread(), true) // add true here if you want to delay the error
                 .subscribeWith(new DisposableSubscriber<Optional<List<Post>>>(){
                     @Override
                     public void onNext(Optional<List<Post>> items) {
                         if(!items.isNull()){
                             mainView.updatePosts(items.get());
-                        } else {
-                            // show up network error (syncing error on your PostService Store)
                         }
                     }
 
@@ -68,10 +68,12 @@ public class MainPresenter {
                     public void onError(Throwable e) {
                         e.printStackTrace();
                         mainView.updatePosts(null);
+                        mainView.showError("Network error");
                     }
 
                     @Override
                     public void onComplete() {
+                        mainView.hideError();
                     }
                 });
 

--- a/example/src/main/java/com/playmoweb/store2realm/example/ui/MainView.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/ui/MainView.java
@@ -13,4 +13,5 @@ public interface MainView {
     void updatePosts(List<Post> posts);
 
     void showError(String message);
+    void hideError();
 }

--- a/example/src/main/java/com/playmoweb/store2realm/example/ui/MainView.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/ui/MainView.java
@@ -11,4 +11,6 @@ import java.util.List;
  */
 public interface MainView {
     void updatePosts(List<Post> posts);
+
+    void showError(String message);
 }

--- a/example/src/main/java/com/playmoweb/store2realm/example/ui/OtherActivity.java
+++ b/example/src/main/java/com/playmoweb/store2realm/example/ui/OtherActivity.java
@@ -1,0 +1,29 @@
+package com.playmoweb.store2realm.example.ui;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+import com.playmoweb.store2realm.example.R;
+
+/**
+ * Created by thibaud on 19/01/2018.
+ */
+
+public class OtherActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_other);
+
+        findViewById(R.id.button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                startActivity(new Intent(OtherActivity.this, MainActivity.class));
+            }
+        });
+
+    }
+}

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -6,10 +6,24 @@
     android:layout_height="match_parent"
     tools:context="com.playmoweb.store2realm.example.ui.MainActivity">
 
+    <TextView
+        android:id="@+id/errorMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="10dp"
+        android:background="#FF44"
+        android:textColor="#FFF"
+        android:textAllCaps="true"
+        android:visibility="gone"
+        tools:visibility="visible"
+        android:text="Network error"/>
+
     <ListView
         android:id="@+id/listOfPosts"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_below="@+id/errorMessage"
         android:layout_above="@+id/buttonsContainer"/>
 
     <LinearLayout

--- a/example/src/main/res/layout/activity_other.xml
+++ b/example/src/main/res/layout/activity_other.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="next"/>
+
+</LinearLayout>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 28 15:26:08 ICT 2017
+#Fri Jan 19 13:00:56 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/store2realm/build.gradle
+++ b/store2realm/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'realm-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16
@@ -29,7 +29,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile 'com.github.playmoweb:store2store:3.0.2'
+    compile 'com.github.playmoweb:store2store:3.0.3'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     testCompile 'junit:junit:4.12'
 }

--- a/store2realm/build.gradle
+++ b/store2realm/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile 'com.github.playmoweb:store2store:3.0.2'
+    compile 'com.github.playmoweb:store2store:3.0.3'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     testCompile 'junit:junit:4.12'
 }

--- a/store2realm/build.gradle
+++ b/store2realm/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile 'com.github.playmoweb:store2store:3.0.3'
+    compile 'com.github.playmoweb:store2store:3.0.2'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     testCompile 'junit:junit:4.12'
 }

--- a/store2realm/src/main/java/com/playmoweb/store2realm/service/BaseRealmService.java
+++ b/store2realm/src/main/java/com/playmoweb/store2realm/service/BaseRealmService.java
@@ -10,9 +10,9 @@ import io.realm.RealmObject;
  * This class try to facilitate usage of Realm with any other async storage system.
  * For now this abstract class implements the most basics CRUD operations only.
  *
- * @author  Thibaud Giovannetti
- * @by      Playmoweb
- * @date    31/01/2017
+ * @author Thibaud Giovannetti
+ * @by Playmoweb
+ * @date 31/01/2017
  */
 public class BaseRealmService<T extends RealmObject & HasId> extends StoreService<T> {
     /**
@@ -21,6 +21,10 @@ public class BaseRealmService<T extends RealmObject & HasId> extends StoreServic
      * @param clazz
      */
     public BaseRealmService(Class<T> clazz) {
-        super(clazz, new RealmDao<>(clazz));
+        this(clazz, false);
+    }
+
+    public BaseRealmService(Class<T> clazz, boolean isCache) {
+        super(clazz, new RealmDao<>(clazz), isCache);
     }
 }

--- a/store2realm/src/main/java/com/playmoweb/store2realm/service/BaseRealmService.java
+++ b/store2realm/src/main/java/com/playmoweb/store2realm/service/BaseRealmService.java
@@ -10,9 +10,9 @@ import io.realm.RealmObject;
  * This class try to facilitate usage of Realm with any other async storage system.
  * For now this abstract class implements the most basics CRUD operations only.
  *
- * @author Thibaud Giovannetti
- * @by Playmoweb
- * @date 31/01/2017
+ * @author  Thibaud Giovannetti
+ * @by      Playmoweb
+ * @date    31/01/2017
  */
 public class BaseRealmService<T extends RealmObject & HasId> extends StoreService<T> {
     /**
@@ -21,10 +21,6 @@ public class BaseRealmService<T extends RealmObject & HasId> extends StoreServic
      * @param clazz
      */
     public BaseRealmService(Class<T> clazz) {
-        this(clazz, false);
-    }
-
-    public BaseRealmService(Class<T> clazz, boolean isCache) {
-        super(clazz, new RealmDao<>(clazz), isCache);
+        super(clazz, new RealmDao<>(clazz));
     }
 }


### PR DESCRIPTION
To use Store2Realm as a cache you can have a look to the example in the project. You just have to pass a second argument (true) to the onObserve method : 

```
postService.getAll(filter, sortingMode)
    .subscribeOn(Schedulers.io())
    .observeOn(AndroidSchedulers.mainThread(), true) // add true here if you want to delay the error and receive the realm update first
    ...
```

Fix #7 